### PR TITLE
Update attenuation in Chapter 7

### DIFF
--- a/MJCF/Chapter7-light&replicate/tutorial.md
+++ b/MJCF/Chapter7-light&replicate/tutorial.md
@@ -17,8 +17,8 @@
 **pos="0 0 0"**     
 **dir="0 0 0"**     
 &emsp;&emsp;方向        
-**attenuation="0 0 0"**     
-&emsp;&emsp;衰减系数,置 0 和 1 为没有衰减。[0,1]范围内越大越衰减      
+**attenuation="1 0 0"**     
+&emsp;&emsp;衰减系数,[a,b,c],I(d)=I_0/a+bd+cd^2。可以看到a,b,c越大，衰减越明显。        
 **cutoff="0"**      
 &emsp;&emsp;聚光灯截止（最大）角度，角度制      
 **exponent="0"**        


### PR DESCRIPTION
Dear Author, 
    Thank you for preparing this awesome Mujoco tutorial. I have found a typo that could cause misunderstanding in Chapter 7 regarding the attribute 'attenuation'. The default value should be '1 0 0' instead of '0 0 0'. Moreover, I have added up a math formula to help understand how attenuation lead to results of light.
Best Regards