### PR TITLE
增加 mj_multiRay 参数 normal

### DIFF
--- a/Python/Chapter7-ray/ray.py
+++ b/Python/Chapter7-ray/ray.py
@@ -57,11 +57,12 @@ with mujoco.viewer.launch_passive(m, d) as viewer:
       for j in range(3):
         num_vec[i*3+j] = boxs_pos[i][j] - cam_pos[0][j]
     geomid = np.zeros((box_num,1), dtype=np.int32)
+    normal = np.zeros((box_num*3,1), dtype=np.float64)
     geomgroup = np.ones((6, 1))
     dist = np.zeros((box_num,1))
     dist_ratio = np.zeros((box_num,1))
     pnt = cam_pos.reshape(3, 1)
-    mujoco.mj_multiRay(m,d,pnt,num_vec,geomgroup,1,-1,geomid,dist_ratio,box_num,999)
+    mujoco.mj_multiRay(m,d,pnt,num_vec,geomgroup,1,-1,geomid,dist_ratio,normal,box_num,999)
     for i in range(box_num):
       if geomid[i] == -1:
         dist[i] = -1.0


### PR DESCRIPTION
在运行Chapter7-ray/ray.py时出现如下报错：
`TypeError: mj_multiRay(): incompatible function arguments. The following argument types are supported:
    1. (m: mujoco._structs.MjModel, d: mujoco._structs.MjData, pnt: typing.Annotated[numpy.typing.NDArray[numpy.float64], "[3, 1]"], vec: typing.Annotated[numpy.typing.NDArray[numpy.float64], "[m, 1]"], geomgroup: typing.Annotated[numpy.typing.NDArray[numpy.uint8], "[6, 1]"] | None, flg_static: bool, bodyexclude: typing.SupportsInt | typing.SupportsIndex, geomid: typing.Annotated[numpy.typing.NDArray[numpy.int32], "[m, 1]", "flags.writeable"], dist: typing.Annotated[numpy.typing.NDArray[numpy.float64], "[m, 1]", "flags.writeable"], normal: typing.Annotated[numpy.typing.NDArray[numpy.float64], "[m, 1]", "flags.writeable"] | None, nray: typing.SupportsInt | typing.SupportsIndex, cutoff: typing.SupportsFloat | typing.SupportsIndex) -> None`
    
报错提示mj_multiRay()需要的参数中包括`normal: typing.Annotated[numpy.typing.NDArray[numpy.float64], "[m, 1]", "flags.writeable"] | None,`，原先的代码中的mj_multiRay()并不包括normal。在您的视频中运行正常，应该是mujoco版本更新增加了normal参数，我增加了这个参数确保程序正常运行。